### PR TITLE
Replace one rogue use of 'mailchimp_client'

### DIFF
--- a/mailchimp_auth/views.py
+++ b/mailchimp_auth/views.py
@@ -215,7 +215,7 @@ class LoginForm(JSONFormResponseMixin, FormView):
         form = self.get_form()
 
         if form.is_valid():
-            user = mailchimp_client.get_supporter(form.cleaned_data['email'])
+            user = MailchimpAPI().get_supporter(form.cleaned_data['email'])
 
             if not user:
                 error_message = (


### PR DESCRIPTION
Missed one old use of `mailchimp_client` within `views`. This replaces it with `MailchimpAPI()`