### PR TITLE
add interest groups and tags to new users

### DIFF
--- a/mailchimp_auth/mailchimp.py
+++ b/mailchimp_auth/mailchimp.py
@@ -14,6 +14,7 @@ class MailchimpAPI(object):
     LIST_ID = settings.MAILCHIMP_LIST_ID
     API_KEY = settings.MAILCHIMP_API_KEY
     SERVER = settings.MAILCHIMP_SERVER
+    INTEREST_ID = settings.MAILCHIMP_INTEREST_ID
 
     def __init__(self):
         try:
@@ -51,13 +52,23 @@ class MailchimpAPI(object):
             "merge_fields": {
                 "FNAME": user.first_name,
                 "LNAME": user.last_name,
+            },
+            "interests": {
+                self.INTEREST_ID: True
             }
+        }
+
+        tag_payload = {
+            "tags": [
+                {"name": "Database Sign-up", "status": "active"}
+            ]
         }
 
         subscriber = payload["email_address"]
 
         try:
             response = self.client.lists.set_list_member(self.LIST_ID, subscriber, payload)
+            self.client.lists.update_list_member_tags(self.LIST_ID, subscriber, tag_payload)
         except ApiClientError as error:
             logging.warning("Error: {}".format(error.text))
             return 'error'  # Used to help display front end errors

--- a/mailchimp_auth/mailchimp.py
+++ b/mailchimp_auth/mailchimp.py
@@ -11,12 +11,14 @@ class MailchimpAPI(object):
     Wrapper for supporter methods:
     https://mailchimp.com/developer/marketing/api/list-members/
     '''
-    LIST_ID = settings.MAILCHIMP_LIST_ID
-    API_KEY = settings.MAILCHIMP_API_KEY
-    SERVER = settings.MAILCHIMP_SERVER
-    INTEREST_ID = settings.MAILCHIMP_INTEREST_ID
 
     def __init__(self):
+        self.LIST_ID = settings.MAILCHIMP_LIST_ID
+        self.API_KEY = settings.MAILCHIMP_API_KEY
+        self.SERVER = settings.MAILCHIMP_SERVER
+        self.INTEREST_ID = settings.MAILCHIMP_INTEREST_ID
+        self.TAG = settings.MAILCHIMP_TAG
+
         try:
             self.client = MailchimpMarketing.Client()
             self.client.set_config({
@@ -60,7 +62,7 @@ class MailchimpAPI(object):
 
         tag_payload = {
             "tags": [
-                {"name": "Database Sign-up", "status": "active"}
+                {"name": self.TAG, "status": "active"}
             ]
         }
 


### PR DESCRIPTION
## Overview
This adds an "interest" (also known as "group") to users upon signup, the id of which is gotten through an environment variable. In the case of BGA, this interest will sign them up to receive The Answer newsletter.

This also adds a tag to users that signup through the Pension and Payroll sites, marking them as a "Database Sign-up"

### Notes
If approved, we'll of course have to add MAILCHIMP_INTEREST_ID to pension and payroll. I can absolutely change their repos to expect this, and add a config var to ia-pensions on heroku. Though I'm unsure of how to add that for payroll since I'm not seeing that on heroku.

## Testing Instructions
- Add this branch to the `requirements.txt` for your local payroll or pension repo and build
- Slot in the secrets found on heroku for the api key, server, and list id
- Add an environment variable `MAILCHIMP_INTEREST_ID` and bring up your payroll/pension container
- Sign up with a new email
  - Fun fact: You can insert a dot into your gmail username and have different emails that refer to the same inbox. So you can use xmedr10@gmail.com and x.medr10@gmail.com as different emails and not have to create new accounts for testing.
- Check your inbox for a confirmation email from The Answer