### PR TITLE
Fix - Assign interests and tags to new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ values.
     MAILCHIMP_API_KEY = '<secret key>'
     MAILCHIMP_SERVER = '<server code>'
     MAILCHIMP_LIST_ID = '<id of list to search within>'
+    MAILCHIMP_INTEREST_ID = '<comma separated string of interest ids (eg. xxx,yyyy,zzzzz)>'
 
     # Name and domain for cookie set for authorized users
     MAILCHIMP_AUTH_COOKIE_NAME = ''  # e.g., mailchimp-auth

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 💃 django-mailchimp-auth
+# 🐵 django-mailchimp-auth
 
 A reusable application to allow users of your Django application to
 "authenticate" against your [Mailchimp](https://mailchimp.com/) user store.
@@ -48,6 +48,7 @@ values.
     MAILCHIMP_SERVER = '<server code>'
     MAILCHIMP_LIST_ID = '<id of list to search within>'
     MAILCHIMP_INTEREST_ID = '<comma separated string of interest ids (eg. xxx,yyyy,zzzzz)>'
+    MAILCHIMP_TAG = '<string value of a tag to add to users (optional)>'
 
     # Name and domain for cookie set for authorized users
     MAILCHIMP_AUTH_COOKIE_NAME = ''  # e.g., mailchimp-auth

--- a/mailchimp_auth/mailchimp.py
+++ b/mailchimp_auth/mailchimp.py
@@ -13,6 +13,7 @@ class MailchimpAPI(object):
     '''
     LIST_ID = settings.MAILCHIMP_LIST_ID
     INTERESTS = settings.MAILCHIMP_INTEREST_ID
+    TAG = settings.MAILCHIMP_TAG
     API_KEY = settings.MAILCHIMP_API_KEY
     SERVER = settings.MAILCHIMP_SERVER
 
@@ -63,6 +64,8 @@ class MailchimpAPI(object):
 
         try:
             response = self.client.lists.set_list_member(self.LIST_ID, subscriber, payload)
+            if not self.TAG == "":
+                self.add_supporter_tag(user.email)
         except ApiClientError as error:
             logging.warning("Error: {}".format(error.text))
             return 'error'  # Used to help display front end errors
@@ -92,3 +95,22 @@ class MailchimpAPI(object):
         else:
             # No single, exact match found
             return None
+        
+    def add_supporter_tag(self, email_address):
+        '''
+        Add a tag to a supporter. This is a separate api call from the add/update call.
+        '''
+
+        payload = {
+            "tags": [
+                {"name": self.TAG, "status": "active"}
+            ]
+        }
+
+        try:
+            response = self.client.lists.update_list_member_tags(self.LIST_ID, email_address, payload)
+        except ApiClientError as error:
+            logging.warning("Error: {}".format(error.text))
+            return 'error'
+        
+        return response

--- a/mailchimp_auth/mailchimp.py
+++ b/mailchimp_auth/mailchimp.py
@@ -11,13 +11,14 @@ class MailchimpAPI(object):
     Wrapper for supporter methods:
     https://mailchimp.com/developer/marketing/api/list-members/
     '''
-    LIST_ID = settings.MAILCHIMP_LIST_ID
-    INTERESTS = settings.MAILCHIMP_INTEREST_ID
-    TAG = settings.MAILCHIMP_TAG
-    API_KEY = settings.MAILCHIMP_API_KEY
-    SERVER = settings.MAILCHIMP_SERVER
 
     def __init__(self):
+        self.LIST_ID = settings.MAILCHIMP_LIST_ID
+        self.API_KEY = settings.MAILCHIMP_API_KEY
+        self.SERVER = settings.MAILCHIMP_SERVER
+        self.INTERESTS = settings.MAILCHIMP_INTEREST_ID
+        self.TAG = settings.MAILCHIMP_TAG
+
         try:
             self.client = MailchimpMarketing.Client()
             self.client.set_config({

--- a/mailchimp_auth/mailchimp.py
+++ b/mailchimp_auth/mailchimp.py
@@ -12,6 +12,7 @@ class MailchimpAPI(object):
     https://mailchimp.com/developer/marketing/api/list-members/
     '''
     LIST_ID = settings.MAILCHIMP_LIST_ID
+    INTERESTS = settings.MAILCHIMP_INTEREST_ID
     API_KEY = settings.MAILCHIMP_API_KEY
     SERVER = settings.MAILCHIMP_SERVER
 
@@ -51,8 +52,12 @@ class MailchimpAPI(object):
             "merge_fields": {
                 "FNAME": user.first_name,
                 "LNAME": user.last_name,
-            }
+            },
+            "interests": {}
         }
+
+        for interest in self.INTERESTS.split(","):  # Add user to each interest group
+            payload["interests"][interest.strip()] = True
 
         subscriber = payload["email_address"]
 


### PR DESCRIPTION
## Overview
This adds the ability to add "interests" (also known as "groups") to users upon signup. The app can accept a string list of one or many id's separated by commas through an environment variable. In the case of BGA, they have one interest id that will subscribe users to the Illinois Answers Newsletter.

Also, this will also add a tag to users if the app has one specified. For BGA, they can use this to keep track of which users signed up through the database.

### Notes
I realized after building this, that this is actually already implemented in PR #4. It looks like I was waiting until the environment variables were added to both bga repos before merging, and then forgot to follow up 😖 apologies!

This version is largely similar, but does have some extras like accepting a string list of ids and adjusting the instructions in the README. I'll go ahead and close that last pr.

Also, the testing instructions here have been brought over from that last pr. For testing this time, I used the command line and a test script to run the functions and confirm things got added since I knew that the email portion worked already.

## Testing Instructions
- Add this branch to the `requirements.txt` for your local payroll or pension repo and build
  - `https://github.com/datamade/django-mailchimp-auth/archive/refs/heads/fix/use-interests.zip`
- Using the variable names found in this branch's README, slot in the secrets found on heroku for the api key, server, list id, interest, and tag
  - I used pensions and temporarily put these vars in `.env.example`
  - You may also need to include settings to enable email sending
- Bring up your payroll/pension container and sign up with a new email
- Check your inbox for a confirmation email from Illinois Answer