### PR TITLE
Add logging to authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ authentication modals, and required JavaScript in templates that require login.
 
 ### Sending Sentry messages to an admin email
 
-If you'd like to send authentication error messages to an admin, simply add a var named `ADMIN_EMAIL` containing that email string to your environment variables.
+This app can send authentication error messages to an admin similar to those sent to sentry. If you have a `SENTRY_DSN` in your environment variables, simply add a var named `ADMIN_EMAIL` containing an email address string as well.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 💃 django-mailchimp-auth
+# 🐒 django-mailchimp-auth
 
 A reusable application to allow users of your Django application to
 "authenticate" against your [Mailchimp](https://mailchimp.com/) user store.
@@ -82,3 +82,8 @@ authentication modals, and required JavaScript in templates that require login.
     ```html
     $('#loginModal').modal()
     ```
+
+
+### Sending Sentry messages to an admin email
+
+If you'd like to send authentication error messages to an admin, simply add a var named `ADMIN_EMAIL` containing that email string to your environment variables.

--- a/mailchimp_auth/templates/emails/authentication_error.html
+++ b/mailchimp_auth/templates/emails/authentication_error.html
@@ -1,0 +1,7 @@
+{% autoescape off %}
+Hello,
+
+A user encountered an error on {{ domain }} during {{ event_type }} -
+
+Error: {{ error_msg }}
+{% endautoescape %}

--- a/mailchimp_auth/views.py
+++ b/mailchimp_auth/views.py
@@ -232,7 +232,6 @@ class LoginForm(JSONFormResponseMixin, FormView):
                 form.errors['email'] = [error_message.format(email=form.cleaned_data['email'])]
                 
                 if os.getenv("SENTRY_DSN"):
-                    # TODO: decide if we need to log this general login error. maybe not
                     err_msg = "Following user not found during login: {}. They most likely entered an unsubscribed email.".format(form.cleaned_data['email'])
                     sentry_sdk.capture_message(err_msg, "warning")
                     send_error_email(err_msg, "login", self.request)

--- a/mailchimp_auth/views.py
+++ b/mailchimp_auth/views.py
@@ -230,7 +230,7 @@ class LoginForm(JSONFormResponseMixin, FormView):
                 form.errors['email'] = [error_message.format(email=form.cleaned_data['email'])]
                 
                 if os.getenv("SENTRY_DSN") not in ["None", ""]:
-                    sentry_sdk.capture_message("User not found during login: {}".format(user), "warning")
+                    sentry_sdk.capture_message("User not found during login: {}".format(form.cleaned_data['email']), "warning")
 
                 return self.form_invalid(form)
             elif user == 'error':
@@ -239,6 +239,10 @@ class LoginForm(JSONFormResponseMixin, FormView):
                     'please contact our <a href="mailto:help@illinoisanswers.org" target="_blank">Data Coordinator</a>.'
                 )
                 form.errors['email'] = [error_message.format(email=form.cleaned_data['email'])]
+
+                if os.getenv("SENTRY_DSN") not in ["None", ""]:
+                    sentry_sdk.capture_message("User received error message during login: {}".format(form.cleaned_data['email']), "warning")
+
                 return self.form_invalid(form)
 
             try:
@@ -288,7 +292,7 @@ class VerifyEmail(RedirectView):
                                     error_message)
 
                 if os.getenv("SENTRY_DSN") not in ["None", ""]:
-                    sentry_sdk.capture_message("Error while adding user to Mailchimp audience: {}".format(user), "warning")
+                    sentry_sdk.capture_message("Error while adding user to Mailchimp audience. UID: {}".format(uid), "warning")
 
                 return redirect(settings.MAILCHIMP_AUTH_REDIRECT_LOCATION)
             else:
@@ -317,7 +321,7 @@ class VerifyEmail(RedirectView):
             
             if os.getenv("SENTRY_DSN") not in ["None", ""]:
                 if user is None:
-                    sentry_sdk.capture_message("Activation link clicked, but corresponding user object not found within local list of users.", "warning")
+                    sentry_sdk.capture_message("Activation link clicked, but corresponding user object not found within local list of users. UID: {}".format(uid), "warning")
                 else:
                     sentry_sdk.capture_message("User clicked invalid activation link: {}".format(user.email), "warning")
 

--- a/mailchimp_auth/views.py
+++ b/mailchimp_auth/views.py
@@ -16,6 +16,8 @@ from django.utils.encoding import force_bytes, force_text
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.views.generic import FormView, RedirectView
 import requests
+import os
+import sentry_sdk
 
 from mailchimp_auth.constants import TEST_PRIVATE_KEY
 from mailchimp_auth.forms import SignUpForm, LoginForm
@@ -101,6 +103,9 @@ class SignUpForm(JSONFormResponseMixin, FormView):
 
             messages.add_message(self.request, messages.INFO, message_title, extra_tags='font-weight-bold')
             messages.add_message(self.request, messages.INFO, message_body)
+            if os.getenv("SENTRY_DSN") not in ["None", ""]:
+                    sentry_sdk.capture_message("Error while looking for user in Mailchimp during sign-up: {}".format(email), "warning")
+
         elif mailchimp_user:
             # Sometimes the user's first name is not in Mailchimp.
             welcome_message = 'Welcome back, {}!'.format(mailchimp_user['merge_fields'].get('FNAME', email))  
@@ -223,6 +228,10 @@ class LoginForm(JSONFormResponseMixin, FormView):
                     'to access this tool.'
                 )
                 form.errors['email'] = [error_message.format(email=form.cleaned_data['email'])]
+                
+                if os.getenv("SENTRY_DSN") not in ["None", ""]:
+                    sentry_sdk.capture_message("User not found during login: {}".format(user), "warning")
+
                 return self.form_invalid(form)
             elif user == 'error':
                 error_message = (
@@ -277,6 +286,10 @@ class VerifyEmail(RedirectView):
                 messages.add_message(self.request,
                                     messages.ERROR,
                                     error_message)
+
+                if os.getenv("SENTRY_DSN") not in ["None", ""]:
+                    sentry_sdk.capture_message("Error while adding user to Mailchimp audience: {}".format(user), "warning")
+
                 return redirect(settings.MAILCHIMP_AUTH_REDIRECT_LOCATION)
             else:
                 email = mailchimp_user['email_address']
@@ -301,6 +314,12 @@ class VerifyEmail(RedirectView):
             messages.add_message(self.request,
                                  messages.ERROR,
                                  contact_message)
+            
+            if os.getenv("SENTRY_DSN") not in ["None", ""]:
+                if user is None:
+                    sentry_sdk.capture_message("Activation link clicked, but corresponding user object not found within local list of users.", "warning")
+                else:
+                    sentry_sdk.capture_message("User clicked invalid activation link: {}".format(user.email), "warning")
 
             return redirect(settings.MAILCHIMP_AUTH_REDIRECT_LOCATION)
 


### PR DESCRIPTION
## Overview

This branch adds logging to almost every portion of the login/signup process. Sentry will now be sent a warning message when those errors occur, with some details on the event. And there is now an option of sending the same errors to an admin as an email.

The only requirements for that emailing to work are adding a new `ADMIN_EMAIL` env variable and ensuring that the app already has a `SENTRY_DSN` var as well.

After this is merged, I'll go ahead and ask BGA for an admin email and add it to production.

- Closes #7

### Testing Instructions
- Add this branch to the `requirements.txt` for your local payroll or pension repo and build
  - `https://github.com/datamade/django-mailchimp-auth/archive/refs/heads/patch/auth-logging.zip`
- Using the variable names found in this branch's README, slot in the secrets found on heroku for the api key, server, list id, interest, and tag
  - I used pensions and temporarily put these vars in `.env.example`
  - You may also need to include settings to enable email sending
- Bring up your payroll/pension container and try to force some errors.
  - Confirm that an email gets sent containing the error message.
  - Personally, I tried logging in with an email that's not subscribed, and clicking old activation links that I had in my inbox. Here's an activation link that'll raise an error on your local instance: http://localhost:8000/mailchimp/verify/ODMyMDM/6c3-54d9040c720797ce79b5/
  - You could also temporarily change the view to force errors as well